### PR TITLE
Hide notification badge

### DIFF
--- a/app/src/main/java/com/thatguysservice/huami_xdrip/UtilityModels/Notifications.java
+++ b/app/src/main/java/com/thatguysservice/huami_xdrip/UtilityModels/Notifications.java
@@ -33,6 +33,7 @@ public class Notifications {
                     NOTIFICATION_CHANNEL_ID,
                     context.getString(R.string.notification_channel_name),
                     NotificationManager.IMPORTANCE_LOW);
+            channelGeneral.setShowBadge(false);
             notificationManager.createNotificationChannel(channelGeneral);
         }
         notificationChannelsCreated = true;


### PR DESCRIPTION
The background service registers a notification as required by Android. 
The badge does not need to show on the icon and could be disabled
https://developer.android.com/develop/ui/views/notifications/badges#java

A channel can not be updated. It requires the re-install to see the results