### PR TITLE
fix: night mode time preference

### DIFF
--- a/app/src/main/java/com/thatguysservice/huami_xdrip/utils/time/TimePreference.java
+++ b/app/src/main/java/com/thatguysservice/huami_xdrip/utils/time/TimePreference.java
@@ -51,13 +51,15 @@ public class TimePreference extends DialogPreference {
             if (defaultValue == null) {
                 calendar.setTimeInMillis(getPersistedLong(System.currentTimeMillis()));
             } else {
-                calendar.setTimeInMillis(Long.parseLong(getPersistedString((String) defaultValue)));
+                calendar.set(Calendar.HOUR_OF_DAY, Integer.parseInt(getPersistedString((String) defaultValue)));
+                calendar.set(Calendar.MINUTE, 0);
             }
         } else {
             if (defaultValue == null) {
                 calendar.setTimeInMillis(System.currentTimeMillis());
             } else {
-                calendar.setTimeInMillis(Long.parseLong((String) defaultValue));
+                calendar.set(Calendar.HOUR_OF_DAY, Integer.parseInt(getPersistedString((String) defaultValue)));
+                calendar.set(Calendar.MINUTE, 0);
             }
         }
         updateSummary();

--- a/app/src/main/java/com/thatguysservice/huami_xdrip/utils/time/TimePreferenceDialogFragmentCompat.java
+++ b/app/src/main/java/com/thatguysservice/huami_xdrip/utils/time/TimePreferenceDialogFragmentCompat.java
@@ -1,6 +1,7 @@
 package com.thatguysservice.huami_xdrip.utils.time;
 
 import android.content.Context;
+import android.text.format.DateFormat;
 import android.view.View;
 import android.widget.TimePicker;
 
@@ -18,6 +19,7 @@ public class TimePreferenceDialogFragmentCompat extends PreferenceDialogFragment
     @Override
     protected View onCreateDialogView(Context context) {
         picker = new TimePicker(context);
+        picker.setIs24HourView(DateFormat.is24HourFormat(getActivity()));
         return picker;
     }
 

--- a/app/src/main/res/xml/advanced_preferences.xml
+++ b/app/src/main/res/xml/advanced_preferences.xml
@@ -37,12 +37,14 @@
             android:key="miband_nightmode_start"
             android:dependency="miband_nightmode_enabled"
             app:allowDividerAbove="false"
+            android:defaultValue="22"
             app:iconSpaceReserved="true"
             android:title="@string/title_miband_nightmode_start">
         </com.thatguysservice.huami_xdrip.utils.time.TimePreference>
         <com.thatguysservice.huami_xdrip.utils.time.TimePreference
             android:key="miband_nightmode_end"
             app:iconSpaceReserved="true"
+            android:defaultValue="7"
             app:allowDividerAbove="false"
             android:dependency="miband_nightmode_enabled"
             android:title="@string/title_miband_nightmode_end">


### PR DESCRIPTION
- Add default for time value night mode `start` and `end`.
- Fix night mode dialog time picker; use 24h format when needed.