### PR TITLE
Upgrade lombok 1.18.10 -> 1.18.30

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -96,9 +96,9 @@ dependencies {
     implementation 'com.squareup.picasso:picasso:2.8'
 
     // you will want to install the android studio lombok plugin
-    compileOnly 'org.projectlombok:lombok:1.18.10'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
     //  compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
-    annotationProcessor "org.projectlombok:lombok:1.18.10"
+    annotationProcessor "org.projectlombok:lombok:1.18.30"
 
 //fix The number of method references in a .dex file cannot exceed 64K error
     implementation 'com.squareup.okhttp:okhttp:2.7.5'


### PR DESCRIPTION
Hi!

On the current main branch, I'm getting this build error:

> Cause: class lombok.javac.apt.LombokProcessor (in unnamed module @0x196abf85) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x196abf85

Changing the Lombok version as the diff here shows fixes it for me.

I'm new to Android development, so I'm not sure if this is the correct fix, but if it is, please consider this PR!

My system is:
* Ubuntu 22.04
* Android Studio Hedgehog | 2023.1.1 Patch 2
* OpenJDK 17.0.10